### PR TITLE
Update installing_marionette.md

### DIFF
--- a/en/getting_started/installing_marionette.md
+++ b/en/getting_started/installing_marionette.md
@@ -18,7 +18,8 @@ install Marionette itself.
   7. Install Marionette: `npm install --save backbone.marionette`
   8. Install the Underscore plugin for browserify:
     `npm install --save node-underscorify`
-  9. Download [jQuery][jquery] and place it in a static folder
+  9. Install jquery `npm install --save jquery`
+  10. Download [jQuery][jquery] and place it in a static folder
 
 Now we have our basics in place, we can setup a standard `setup.js` file that
 will ensure Marionette can be accessed:
@@ -32,7 +33,7 @@ Backbone.Marionette = require('backbone.marionette');
 ```
 
 When building our applications, we'll commonly use a `driver.js` file that will
-start by importing this `setup.js` file: `require('setup.js')`.
+start by importing this `setup.js` file: `require('./setup.js')`.
 
 When we want to compile our application, we'll use Browserify:
 


### PR DESCRIPTION
Two fixes so that these steps can be followed without error.
1. Jquery must be explicitly installed. See discussion [here](https://github.com/marionettejs/backbone.marionette/issues/535)
2. require needs to use `./` to refer to a file that is in the same folder. Otherwise it will search in node_modules.
