### PR TITLE
Fix the creation of Marionette.Application in the tutorial.

### DIFF
--- a/en/getting_started/tutorial/layouts.md
+++ b/en/getting_started/tutorial/layouts.md
@@ -109,7 +109,7 @@ var initialData = {
   ]
 };
 
-var App = new Marionette.Application({
+var app = new Marionette.Application({
   onStart: function(options) {
     var todo = new TodoView({
       collection: new Backbone.Collection(this.getOption('initialData')),
@@ -120,7 +120,7 @@ var App = new Marionette.Application({
   }
 });
 
-App.start({initialData: initialData});
+app.start({initialData: initialData});
 ```
 
 

--- a/en/getting_started/tutorial/layouts.md
+++ b/en/getting_started/tutorial/layouts.md
@@ -120,8 +120,7 @@ var App = new Marionette.Application({
   }
 });
 
-var app = new App();
-app.start({initialData: initialData});
+App.start({initialData: initialData});
 ```
 
 

--- a/fr/getting_started/tutorial/layouts.md
+++ b/fr/getting_started/tutorial/layouts.md
@@ -114,7 +114,7 @@ var initialData = {
   ]
 };
 
-var App = new Marionette.Application({
+var app = new Marionette.Application({
   onStart: function(options) {
     var todo = new TodoView(options);
     todo.render();
@@ -122,7 +122,7 @@ var App = new Marionette.Application({
   }
 });
 
-App.start({initialData: initialData});
+app.start({initialData: initialData});
 ```
 
 

--- a/fr/getting_started/tutorial/layouts.md
+++ b/fr/getting_started/tutorial/layouts.md
@@ -122,8 +122,7 @@ var App = new Marionette.Application({
   }
 });
 
-var app = new App();
-app.start({initialData: initialData});
+App.start({initialData: initialData});
 ```
 
 


### PR DESCRIPTION
Note: It didn't work as stated in the example because we either instantiate the default `Marionette.Application` and call `.start()`on the instance or we extend by calling `Marionette.Application.extend`, then create a `new App` and then call `.start()`.
